### PR TITLE
Add financing pages

### DIFF
--- a/asset-backed-lending.html
+++ b/asset-backed-lending.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Asset-Backed Lending | Financely</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 2rem;
+            line-height: 1.6;
+        }
+        h1 {
+            font-size: 1.8rem;
+        }
+        .cta {
+            display: inline-block;
+            margin-top: 1rem;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white;
+            text-decoration: none;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <h1>Asset-Backed Lending</h1>
+    <p>Use receivables, inventory, and equipment to unlock working capital. Financely connects you to lenders that advance funds against your assets so you can move quickly.</p>
+    <p><a class="cta" href="index.html">Home</a></p>
+</body>
+</html>

--- a/commercial-real-estate.html
+++ b/commercial-real-estate.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Commercial Real Estate | Financely</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 2rem;
+            line-height: 1.6;
+        }
+        h1 {
+            font-size: 1.8rem;
+        }
+        .cta {
+            display: inline-block;
+            margin-top: 1rem;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white;
+            text-decoration: none;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <h1>Commercial Real Estate</h1>
+    <p>From acquisition to development, Financely introduces you to lenders that fund office, industrial, retail, and mixed-use properties around the world.</p>
+    <p><a class="cta" href="index.html">Home</a></p>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -29,7 +29,17 @@
 </head>
 <body>
     <h1>Financing that fits</h1>
-    <p>Financely connects borrowers with lenders across trade finance, project finance, commercial real estate, and M&A. If you’re a founder or CFO racing the clock, you’ll find capital options here without jumping through endless hoops. We also wrap each deal in the help you need—due-diligence packaging, credit insurance, escrow services, FX hedging, and legal structuring are all within reach.</p>
+    <p>Financely connects borrowers with lenders across trade finance, project finance, commercial real estate, and M&amp;A. If you’re a founder or CFO racing the clock, you’ll find capital options here without jumping through endless hoops. We also wrap each deal in the help you need—due-diligence packaging, credit insurance, escrow services, FX hedging, and legal structuring are all within reach.</p>
+<h2>Explore financing options</h2>
+    <ul>
+        <li><a href="trade-finance.html">Trade Finance</a></li>
+        <li><a href="project-finance.html">Project Finance</a></li>
+        <li><a href="commercial-real-estate.html">Commercial Real Estate</a></li>
+        <li><a href="m-and-a.html">M&amp;A Finance</a></li>
+        <li><a href="asset-backed-lending.html">Asset-Backed Lending</a></li>
+        <li><a href="private-credit.html">Private Credit</a></li>
+    </ul>
+
     <h2>Why Financely?</h2>
     <ul>
         <li>Fast access to vetted capital providers</li>

--- a/m-and-a.html
+++ b/m-and-a.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>M&amp;A Finance | Financely</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 2rem;
+            line-height: 1.6;
+        }
+        h1 {
+            font-size: 1.8rem;
+        }
+        .cta {
+            display: inline-block;
+            margin-top: 1rem;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white;
+            text-decoration: none;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <h1>M&amp;A Finance</h1>
+    <p>Financely links acquisition-minded companies with lenders comfortable structuring leverage for buyouts and rollups.</p>
+    <p><a class="cta" href="index.html">Home</a></p>
+</body>
+</html>

--- a/private-credit.html
+++ b/private-credit.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Private Credit | Financely</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 2rem;
+            line-height: 1.6;
+        }
+        h1 {
+            font-size: 1.8rem;
+        }
+        .cta {
+            display: inline-block;
+            margin-top: 1rem;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white;
+            text-decoration: none;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <h1>Private Credit</h1>
+    <p>Private credit involves non-bank lenders providing debt financing directly to businesses. These lenders look for opportunities outside traditional public markets, offering flexible structures and faster execution.</p>
+    <p>Financely maintains a network of private credit funds and family offices looking to deploy capital. Our platform matches their lending mandates with your borrowing needs, cutting down the weeks it normally takes to source the right partner.</p>
+    <p><a class="cta" href="index.html">Home</a></p>
+</body>
+</html>

--- a/project-finance.html
+++ b/project-finance.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Project Finance | Financely</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 2rem;
+            line-height: 1.6;
+        }
+        h1 {
+            font-size: 1.8rem;
+        }
+        .cta {
+            display: inline-block;
+            margin-top: 1rem;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white;
+            text-decoration: none;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <h1>Project Finance</h1>
+    <p>Whether it’s power, infrastructure, or industrial development, Financely helps you secure non-recourse funding from institutions that understand large-scale projects.</p>
+    <p><a class="cta" href="index.html">Home</a></p>
+</body>
+</html>

--- a/trade-finance.html
+++ b/trade-finance.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Trade Finance | Financely</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 2rem;
+            line-height: 1.6;
+        }
+        h1 {
+            font-size: 1.8rem;
+        }
+        .cta {
+            display: inline-block;
+            margin-top: 1rem;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white;
+            text-decoration: none;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <h1>Trade Finance</h1>
+    <p>Keep goods moving with letters of credit, supply chain finance, and factoring solutions. Financely connects you with funders who specialize in cross-border trade.</p>
+    <p><a class="cta" href="index.html">Home</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated pages for trade finance, project finance, commercial real estate, M&A, and asset-backed lending
- explain private credit and matching borrowers with lenders
- update homepage with links to these pages

## Testing
- `tidy -errors index.html`
- `tidy -errors m-and-a.html`
- `tidy -errors trade-finance.html project-finance.html commercial-real-estate.html asset-backed-lending.html private-credit.html`

------
https://chatgpt.com/codex/tasks/task_e_6847747b668483288a1dba25ce99c6e5