### PR TITLE
Add service pages and links

### DIFF
--- a/commercial-real-estate.html
+++ b/commercial-real-estate.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Commercial Real Estate | Financely</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="hero">
+    <h1>Commercial Real Estate</h1>
+    <section class="detail">
+      <h2>What we do</h2>
+      <p>We secure senior, mezz, and preferred equity for income-producing or value-add assets—multifamily, logistics, hospitality, and specialty use. Ticket sizes run USD 10–50 million. Borrowers come to us when traditional lenders balk at timeline, lease-up, or cross-border complexity.</p>
+      <h2>Capital stack options</h2>
+      <p>Bridge loans, construction loans, credit-tenant leases, and hybrid debt-equity tranches.</p>
+      <h2>Why it matters</h2>
+      <p>A stalled closing kills IRR. We bring lenders who thrive on tight deadlines and structuring quirks.</p>
+      <h2>Next step</h2>
+      <p>Share the rent roll or development model. We’ll map the stack and circle interested lenders within a week.</p>
+    </section>
+    <a class="btn" href="https://www.financely-group.com/contact-us">Request a Quote</a>
+  </main>
+  <footer>
+    <p>© 2025 Financely</p>
+    <p class="disclaimer">Financely is not a licensed broker-dealer; all advisory or introductory services are provided under contract.</p>
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -12,6 +12,12 @@
     <h2>Funding that fits your vision</h2>
     <p>We underwrite, structure, and distribute transactions to a global private credit network.</p>
     <a class="btn" href="https://www.financely-group.com/contact-us">Request a Quote</a>
+    <div class="services">
+      <a class="service" href="structured-trade.html">Structured Trade &amp; Commodity Finance</a>
+      <a class="service" href="commercial-real-estate.html">Commercial Real Estate</a>
+      <a class="service" href="project-finance.html">Project Finance</a>
+      <a class="service" href="m-and-a.html">M&amp;A</a>
+    </div>
   </main>
   <footer>
     <p>© 2025 Financely</p>

--- a/m-and-a.html
+++ b/m-and-a.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>M&A | Financely</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="hero">
+    <h1>M&amp;A</h1>
+    <section class="detail">
+      <h2>What we do</h2>
+      <p>We raise acquisition financing and recapitalisation tranches for lower-mid-market buyouts—enterprise values USD 10–75 million. Solutions span unitranche, seller notes, holdco PIK, and minority equity co-investment. Speed is critical once the LOI lands; we work back from the SPA date to guarantee funds at signing.</p>
+      <h2>Targets we back</h2>
+      <p>Profitable niche manufacturers, infrastructure service firms, technology horizontals with sticky cash-flow.</p>
+      <h2>Why it matters</h2>
+      <p>Lose the financing edge and the deal slips to a rival. We keep your bid credible and your closing timetable intact.</p>
+      <h2>Next step</h2>
+      <p>Send the CIM and purchase price schedule. We’ll frame leverage capacity and term-sheet milestones in 48 hours.</p>
+    </section>
+    <a class="btn" href="https://www.financely-group.com/contact-us">Request a Quote</a>
+  </main>
+  <footer>
+    <p>© 2025 Financely</p>
+    <p class="disclaimer">Financely is not a licensed broker-dealer; all advisory or introductory services are provided under contract.</p>
+  </footer>
+</body>
+</html>

--- a/project-finance.html
+++ b/project-finance.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Project Finance | Financely</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="hero">
+    <h1>Project Finance</h1>
+    <section class="detail">
+      <h2>What we do</h2>
+      <p>We build complete funding programs for energy, infrastructure, and industrial projects from USD 20 million upward. Our scope covers feasibility review, risk allocation, offtake validation, and lender roadshows. Debt tenors stretch 7–15 years; coverage ratios are negotiated case by case.</p>
+      <h2>Typical assets</h2>
+      <p>Solar or wind parks, mid-stream logistics, waste-to-energy, data centres, ports.</p>
+      <h2>Why it matters</h2>
+      <p>Projects fail when capital comes piecemeal. We align sponsors, contractors, and lenders behind a single credit story and lock pricing before EPC mobilises.</p>
+      <h2>Next step</h2>
+      <p>Provide your financial model and permits list. We’ll flag gaps and outline a funding timeline within five business days.</p>
+    </section>
+    <a class="btn" href="https://www.financely-group.com/contact-us">Request a Quote</a>
+  </main>
+  <footer>
+    <p>© 2025 Financely</p>
+    <p class="disclaimer">Financely is not a licensed broker-dealer; all advisory or introductory services are provided under contract.</p>
+  </footer>
+</body>
+</html>

--- a/structured-trade.html
+++ b/structured-trade.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Structured Trade & Commodity Finance | Financely</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="hero">
+    <h1>Structured Trade &amp; Commodity Finance</h1>
+    <section class="detail">
+      <h2>What we do</h2>
+      <p>We arrange short- to mid-term credit for live commodity flows—oil, metals, agri, and everything in between. Deals start at USD 5 million and are anchored by verifiable purchase contracts, receivables, or inventory. Our team packages each transaction, locks in collateral controls, and lines up private credit funds, trade banks, and insurers that move inside 45 days.</p>
+      <h2>Typical structures</h2>
+      <p>Pre-export finance, borrowing-base lines, receivables discounting, LC back-to-back funding, performance bonds.</p>
+      <h2>Why it matters</h2>
+      <p>Miss a shipment window and profit evaporates. We keep cargo moving and counterparties calm.</p>
+      <h2>Next step</h2>
+      <p>Send the draft contract or pro-forma invoice. We’ll return an indicative term sheet in 72 hours.</p>
+    </section>
+    <a class="btn" href="https://www.financely-group.com/contact-us">Request a Quote</a>
+  </main>
+  <footer>
+    <p>© 2025 Financely</p>
+    <p class="disclaimer">Financely is not a licensed broker-dealer; all advisory or introductory services are provided under contract.</p>
+  </footer>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -41,3 +41,46 @@ footer {
   padding: 2rem 1rem;
   font-size: 0.875rem;
 }
+
+.detail {
+  max-width: 600px;
+  margin: 0 auto 2rem;
+  text-align: left;
+}
+
+.services {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+  margin-top: 2rem;
+  max-width: 800px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.service {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  border: 1px solid var(--clr-primary);
+  border-radius: 3px;
+  background-color: #f0f4fa;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  color: var(--clr-primary);
+  text-decoration: none;
+  transition: transform 0.2s, box-shadow 0.2s, background-color 0.2s;
+}
+
+.service:visited {
+  color: var(--clr-primary);
+}
+
+.service:hover {
+  background-color: #e8edf5;
+}
+
+.service:active {
+  transform: scale(1.05);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}


### PR DESCRIPTION
## Summary
- link each service item on the home page
- add separate pages for each service with matching layout
- tweak styles so services act as links and center details

## Testing
- `npm test` *(fails: Could not read package.json)*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_684814762f5083288a741ec581b99462