### PR TITLE
Add Financely monorepo scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Node
+node_modules/
+.financely
+**/dist/
+**/build/
+# Logs
+logs
+*.log
+npm-debug.log*
+# Env
+.env
+**/*.env
+# OS
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # fgcasolutions.github.io
 
 This repository hosts a simple landing page for Financely. The site contains a single hero section with a call-to-action link and a disclaimer footer.
+
+## Financely Monorepo
+
+The `financely/` directory contains a sample implementation of Financely's platform with multiple services, front-end, design system, and infrastructure manifests. Each service is typed with TypeScript or Go and includes TODO comments for business logic.

--- a/financely/.eslintrc.js
+++ b/financely/.eslintrc.js
@@ -1,0 +1,15 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint', 'react'],
+  extends: ['eslint:recommended', 'plugin:react/recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
+  env: {
+    node: true,
+    es2022: true,
+    jest: true,
+    browser: true
+  },
+  settings: {
+    react: { version: 'detect' }
+  }
+};

--- a/financely/.github/workflows/ci.yml
+++ b/financely/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+on:
+  push:
+    branches: [ main ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - run: npm install
+      - run: npm run lint
+      - run: npm test

--- a/financely/.prettierrc
+++ b/financely/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/financely/README.md
+++ b/financely/README.md
@@ -1,0 +1,19 @@
+# Financely Monorepo
+
+This monorepo contains the core applications and services for the **Financely** platform. It demonstrates a React front‑end, a GraphQL gateway with Node microservices, a Go service for deal matching, and sample infrastructure for Postgres, ElasticSearch, ClickHouse, and NATS.
+
+Each package is written in TypeScript or Go with placeholder business logic. TODO comments highlight where real implementations are required.
+
+```
+financely/
+  packages/
+    frontend/          – Vite + React + TypeScript app
+    design-system/     – Storybook and Tailwind components
+    gateway/           – Apollo GraphQL gateway
+    business-service/  – Node microservice for business rules
+    deal-matcher/      – Go service for high‑throughput matching
+  infra/               – Dockerfiles and Kubernetes manifests
+  sample-events/       – Example NATS event payloads
+```
+
+Run `npm install` at the repository root to install all workspace dependencies.

--- a/financely/infra/dockerfiles/.dockerignore
+++ b/financely/infra/dockerfiles/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/financely/infra/dockerfiles/business-service.Dockerfile
+++ b/financely/infra/dockerfiles/business-service.Dockerfile
@@ -1,0 +1,5 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY ../../packages/business-service .
+RUN npm install && npm run build
+CMD ["node", "dist/index.js"]

--- a/financely/infra/dockerfiles/deal-matcher.Dockerfile
+++ b/financely/infra/dockerfiles/deal-matcher.Dockerfile
@@ -1,0 +1,5 @@
+FROM golang:1.21-alpine
+WORKDIR /app
+COPY ../../packages/deal-matcher .
+RUN go build -o deal-matcher
+CMD ["./deal-matcher"]

--- a/financely/infra/dockerfiles/frontend.Dockerfile
+++ b/financely/infra/dockerfiles/frontend.Dockerfile
@@ -1,0 +1,5 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY ../../packages/frontend .
+RUN npm install && npm run build
+CMD ["npm", "run", "dev"]

--- a/financely/infra/dockerfiles/gateway.Dockerfile
+++ b/financely/infra/dockerfiles/gateway.Dockerfile
@@ -1,0 +1,5 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY ../../packages/gateway .
+RUN npm install && npm run build
+CMD ["node", "dist/index.js"]

--- a/financely/infra/k8s/databases.yaml
+++ b/financely/infra/k8s/databases.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15
+          env:
+            - name: POSTGRES_PASSWORD
+              value: example
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: elasticsearch
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: elasticsearch
+  template:
+    metadata:
+      labels:
+        app: elasticsearch
+    spec:
+      containers:
+        - name: elasticsearch
+          image: elasticsearch:8.11.1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: clickhouse
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: clickhouse
+  template:
+    metadata:
+      labels:
+        app: clickhouse
+    spec:
+      containers:
+        - name: clickhouse
+          image: yandex/clickhouse-server:latest
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nats
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nats
+  template:
+    metadata:
+      labels:
+        app: nats
+    spec:
+      containers:
+        - name: nats
+          image: nats:2.10
+          ports:
+            - containerPort: 4222

--- a/financely/infra/k8s/gateway-deployment.yaml
+++ b/financely/infra/k8s/gateway-deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gateway
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: gateway
+  template:
+    metadata:
+      labels:
+        app: gateway
+    spec:
+      containers:
+        - name: gateway
+          image: gateway:latest
+          ports:
+            - containerPort: 4000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gateway-canary
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gateway-canary
+  template:
+    metadata:
+      labels:
+        app: gateway-canary
+    spec:
+      containers:
+        - name: gateway
+          image: gateway:canary
+          ports:
+            - containerPort: 4000

--- a/financely/jest.config.js
+++ b/financely/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  testEnvironment: 'node',
+  roots: ['<rootDir>/packages'],
+  transform: {
+    '^.+\\.(ts|tsx)$': 'ts-jest'
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: 'coverage'
+};

--- a/financely/package.json
+++ b/financely/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "financely-monorepo",
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ],
+  "scripts": {
+    "build": "npm run build -w frontend && npm run build -w gateway && npm run build -w business-service && npm run build -w deal-matcher",
+    "test": "npm run test -w frontend && npm run test -w gateway && npm run test -w business-service",
+    "lint": "eslint \"packages/**/*.{ts,tsx}\"",
+    "format": "prettier --write \"packages/**/*.{ts,tsx,js,jsx,json}\""
+  },
+  "devDependencies": {
+    "eslint": "^8.56.0",
+    "eslint-config-prettier": "^8.10.0",
+    "eslint-plugin-react": "^7.33.1",
+    "jest": "^29.6.2",
+    "prettier": "^2.8.8",
+    "typescript": "^5.2.2"
+  }
+}

--- a/financely/packages/business-service/jest.config.js
+++ b/financely/packages/business-service/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node'
+};

--- a/financely/packages/business-service/package.json
+++ b/financely/packages/business-service/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@financely/business-service",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "ts-node src/index.ts",
+    "build": "tsc",
+    "test": "jest"
+  },
+  "dependencies": {
+    "apollo-server": "^3.12.0",
+    "graphql": "^16.6.0",
+    "pg": "^8.11.0"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2",
+    "jest": "^29.6.2",
+    "ts-jest": "^29.1.0"
+  }
+}

--- a/financely/packages/business-service/src/index.test.ts
+++ b/financely/packages/business-service/src/index.test.ts
@@ -1,0 +1,8 @@
+import { ApolloServer } from 'apollo-server';
+import { DocumentNode } from 'graphql';
+import { typeDefs } from './schema'; // TODO when schema is separated
+
+// Placeholder test
+it('placeholder', () => {
+  expect(true).toBe(true);
+});

--- a/financely/packages/business-service/src/index.ts
+++ b/financely/packages/business-service/src/index.ts
@@ -1,0 +1,8 @@
+import { ApolloServer } from 'apollo-server';
+import { typeDefs } from './schema';
+import { resolvers } from './resolvers';
+
+const server = new ApolloServer({ typeDefs, resolvers });
+server.listen({ port: 5000 }).then(({ url }) => {
+  console.log(`Business service ready at ${url}`);
+});

--- a/financely/packages/business-service/src/resolvers.ts
+++ b/financely/packages/business-service/src/resolvers.ts
@@ -1,0 +1,8 @@
+export const resolvers = {
+  Query: {
+    deals: async () => {
+      // TODO: read from Postgres
+      return [];
+    }
+  }
+};

--- a/financely/packages/business-service/src/schema.ts
+++ b/financely/packages/business-service/src/schema.ts
@@ -1,0 +1,11 @@
+import { gql } from 'apollo-server';
+
+export const typeDefs = gql`
+  type Deal {
+    id: ID!
+    name: String!
+  }
+  type Query {
+    deals: [Deal!]!
+  }
+`;

--- a/financely/packages/business-service/tsconfig.json
+++ b/financely/packages/business-service/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/financely/packages/deal-matcher/go.mod
+++ b/financely/packages/deal-matcher/go.mod
@@ -1,0 +1,7 @@
+module github.com/financely/deal-matcher
+
+go 1.21
+
+require (
+github.com/nats-io/nats.go v1.26.0
+)

--- a/financely/packages/deal-matcher/main.go
+++ b/financely/packages/deal-matcher/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+    "log"
+    nats "github.com/nats-io/nats.go"
+)
+
+func main() {
+    // TODO: implement high-throughput matching logic
+    nc, err := nats.Connect(nats.DefaultURL)
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer nc.Drain()
+
+    log.Println("Deal matcher service running")
+    select {}
+}

--- a/financely/packages/design-system/package.json
+++ b/financely/packages/design-system/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@financely/design-system",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build"
+  },
+  "dependencies": {
+    "react": "^18.2.0"
+  },
+  "devDependencies": {
+    "@storybook/react": "^7.5.0",
+    "typescript": "^5.2.2"
+  }
+}

--- a/financely/packages/design-system/src/Button.stories.tsx
+++ b/financely/packages/design-system/src/Button.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from './Button';
+
+const meta: Meta<typeof Button> = {
+  title: 'Button',
+  component: Button
+};
+
+export default meta;
+type Story = StoryObj<typeof Button>;
+
+export const Primary: Story = {
+  args: {
+    label: 'Click Me'
+  }
+};

--- a/financely/packages/design-system/src/Button.tsx
+++ b/financely/packages/design-system/src/Button.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  label: string;
+}
+
+export const Button: React.FC<ButtonProps> = ({ label, ...props }) => (
+  <button className="bg-muted-green text-white px-3 py-1 rounded" {...props}>
+    {label}
+  </button>
+);

--- a/financely/packages/design-system/tsconfig.json
+++ b/financely/packages/design-system/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/financely/packages/frontend/index.html
+++ b/financely/packages/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Financely</title>
+  </head>
+  <body class="bg-navy text-white">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/financely/packages/frontend/jest.config.js
+++ b/financely/packages/frontend/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom'
+};

--- a/financely/packages/frontend/package.json
+++ b/financely/packages/frontend/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@financely/frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "test": "jest",
+    "lint": "eslint src --ext .ts,.tsx",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build"
+  },
+  "dependencies": {
+    "@apollo/client": "^3.8.0",
+    "graphql": "^16.6.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.15",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.0.0",
+    "tailwindcss": "^3.3.3",
+    "postcss": "^8.4.24",
+    "autoprefixer": "^10.4.14",
+    "vite": "^4.5.0",
+    "jest": "^29.6.2",
+    "ts-jest": "^29.1.0",
+    "typescript": "^5.2.2",
+    "storybook": "^7.5.0"
+  }
+}

--- a/financely/packages/frontend/postcss.config.cjs
+++ b/financely/packages/frontend/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/financely/packages/frontend/src/App.test.tsx
+++ b/financely/packages/frontend/src/App.test.tsx
@@ -1,0 +1,7 @@
+import { render } from '@testing-library/react';
+import App from './App';
+
+it('renders header', () => {
+  const { getByText } = render(<App />);
+  expect(getByText('Financely')).toBeInTheDocument();
+});

--- a/financely/packages/frontend/src/App.tsx
+++ b/financely/packages/frontend/src/App.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+import { useDeals } from './hooks/useDeals';
+
+export default function App() {
+  const { data } = useDeals();
+  const [dark, setDark] = useState(true);
+  return (
+    <div className={dark ? 'dark' : ''}>
+      <header className="p-4 bg-navy text-white flex justify-between">
+        <h1>Financely</h1>
+        <button
+          className="bg-muted-green px-4 py-1 rounded"
+          onClick={() => setDark(!dark)}
+        >
+          Toggle Theme
+        </button>
+      </header>
+      <main className="p-4">
+        <h2 className="text-muted-green">Deals</h2>
+        <ul>
+          {data?.deals.map((d: any) => (
+            <li key={d.id}>{d.name}</li>
+          ))}
+        </ul>
+      </main>
+    </div>
+  );
+}

--- a/financely/packages/frontend/src/components/KPIView.tsx
+++ b/financely/packages/frontend/src/components/KPIView.tsx
@@ -1,0 +1,4 @@
+export function KPIView() {
+  // TODO: implement tile-based KPI dashboard
+  return <div>KPI View</div>;
+}

--- a/financely/packages/frontend/src/components/Pipeline.tsx
+++ b/financely/packages/frontend/src/components/Pipeline.tsx
@@ -1,0 +1,4 @@
+export function Pipeline() {
+  // TODO: implement Kanban pipeline UI
+  return <div>Pipeline</div>;
+}

--- a/financely/packages/frontend/src/hooks/useDeals.ts
+++ b/financely/packages/frontend/src/hooks/useDeals.ts
@@ -1,0 +1,14 @@
+import { gql, useQuery } from '@apollo/client';
+
+const DEALS_QUERY = gql`
+  query Deals {
+    deals {
+      id
+      name
+    }
+  }
+`;
+
+export function useDeals() {
+  return useQuery(DEALS_QUERY);
+}

--- a/financely/packages/frontend/src/index.css
+++ b/financely/packages/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/financely/packages/frontend/src/main.tsx
+++ b/financely/packages/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/financely/packages/frontend/tailwind.config.js
+++ b/financely/packages/frontend/tailwind.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        navy: '#001f3f',
+        'muted-green': '#3d9970'
+      }
+    }
+  },
+  darkMode: 'class',
+  plugins: []
+};

--- a/financely/packages/frontend/tsconfig.json
+++ b/financely/packages/frontend/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/financely/packages/frontend/vite.config.ts
+++ b/financely/packages/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000
+  }
+});

--- a/financely/packages/gateway/jest.config.js
+++ b/financely/packages/gateway/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node'
+};

--- a/financely/packages/gateway/package.json
+++ b/financely/packages/gateway/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@financely/gateway",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "ts-node src/index.ts",
+    "build": "tsc",
+    "test": "jest"
+  },
+  "dependencies": {
+    "apollo-server": "^3.12.0",
+    "graphql": "^16.6.0",
+    "@apollo/gateway": "^2.5.4",
+    "jsonwebtoken": "^9.0.0",
+    "bcrypt": "^5.1.0"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2",
+    "jest": "^29.6.2",
+    "ts-jest": "^29.1.0"
+  }
+}

--- a/financely/packages/gateway/src/index.ts
+++ b/financely/packages/gateway/src/index.ts
@@ -1,0 +1,14 @@
+import { ApolloServer } from 'apollo-server';
+import { readFileSync } from 'fs';
+import { resolvers } from './resolvers';
+import { userResolvers } from './userResolvers';
+
+const typeDefs = readFileSync(__dirname + '/schema.graphql', 'utf8');
+
+const mergedResolvers = { ...resolvers, ...userResolvers };
+
+const server = new ApolloServer({ typeDefs, resolvers: mergedResolvers });
+
+server.listen({ port: 4000 }).then(({ url }) => {
+  console.log(`Gateway ready at ${url}`);
+});

--- a/financely/packages/gateway/src/kyc.ts
+++ b/financely/packages/gateway/src/kyc.ts
@@ -1,0 +1,11 @@
+import fetch from 'node-fetch';
+
+export async function verifyWithTrulioo(data: any) {
+  // TODO: call Trulioo API
+  await fetch('https://api.trulioo.com/verify', { method: 'POST', body: JSON.stringify(data) });
+}
+
+export async function verifyWithOnfido(data: any) {
+  // TODO: call Onfido API
+  await fetch('https://api.onfido.com/verify', { method: 'POST', body: JSON.stringify(data) });
+}

--- a/financely/packages/gateway/src/resolvers.test.ts
+++ b/financely/packages/gateway/src/resolvers.test.ts
@@ -1,0 +1,8 @@
+import { resolvers } from './resolvers';
+
+describe('resolvers', () => {
+  it('returns empty deals list', async () => {
+    const result = await resolvers.Query.deals();
+    expect(result).toEqual([]);
+  });
+});

--- a/financely/packages/gateway/src/resolvers.ts
+++ b/financely/packages/gateway/src/resolvers.ts
@@ -1,0 +1,14 @@
+export const resolvers = {
+  Query: {
+    deals: async () => {
+      // TODO: fetch from business-service via GraphQL federation or REST
+      return [];
+    }
+  },
+  Mutation: {
+    createDeal: async (_: any, { input }: any) => {
+      // TODO: implement creation logic
+      return { id: '1', name: input.name };
+    }
+  }
+};

--- a/financely/packages/gateway/src/schema.graphql
+++ b/financely/packages/gateway/src/schema.graphql
@@ -1,0 +1,30 @@
+"""Sample schema"""
+type Deal {
+  id: ID!
+  name: String!
+}
+
+type Query {
+  deals: [Deal!]!
+}
+
+input DealInput {
+  name: String!
+}
+
+type Mutation {
+  createDeal(input: DealInput!): Deal!
+}
+input RegisterUserInput {
+  email: String!
+  password: String!
+}
+
+type User {
+  id: ID!
+  email: String!
+}
+
+extend type Mutation {
+  registerUser(input: RegisterUserInput!): User!
+}

--- a/financely/packages/gateway/src/security.ts
+++ b/financely/packages/gateway/src/security.ts
@@ -1,0 +1,26 @@
+import argon2 from 'argon2';
+import jwt from 'jsonwebtoken';
+
+export async function hashPassword(password: string): Promise<string> {
+  return argon2.hash(password);
+}
+
+export function verifyJwt(token: string): any {
+  // TODO: verify token with OAuth2/OIDC provider
+  return jwt.decode(token);
+}
+
+export function encryptEnvelope(data: Buffer, key: Buffer): Buffer {
+  // TODO: implement AES-GCM envelope encryption
+  return data;
+}
+
+export function verifyWebAuthn(assertion: any): boolean {
+  // TODO: implement WebAuthn assertion verification
+  return false;
+}
+
+export function behavioralBiometricCheck(data: unknown): boolean {
+  // TODO: analyze user behavior metrics
+  return true;
+}

--- a/financely/packages/gateway/src/userResolvers.test.ts
+++ b/financely/packages/gateway/src/userResolvers.test.ts
@@ -1,0 +1,8 @@
+import { userResolvers } from './userResolvers';
+
+describe('userResolvers', () => {
+  it('registerUser hashes password', async () => {
+    const res = await userResolvers.Mutation.registerUser(null, { input: { email: 'a@b.com', password: 'pass' }});
+    expect(res.password).not.toBe('pass');
+  });
+});

--- a/financely/packages/gateway/src/userResolvers.ts
+++ b/financely/packages/gateway/src/userResolvers.ts
@@ -1,0 +1,13 @@
+import { hashPassword } from './security';
+import { verifyWithTrulioo } from './kyc';
+
+export const userResolvers = {
+  Mutation: {
+    registerUser: async (_: any, { input }: any) => {
+      // TODO: store user in Postgres
+      await verifyWithTrulioo(input);
+      const hashed = await hashPassword(input.password);
+      return { id: 'u1', email: input.email, password: hashed };
+    }
+  }
+};

--- a/financely/packages/gateway/tsconfig.json
+++ b/financely/packages/gateway/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/financely/sample-events/deal-created.json
+++ b/financely/sample-events/deal-created.json
@@ -1,0 +1,7 @@
+{
+  "type": "deal.created",
+  "payload": {
+    "id": "123",
+    "name": "Series A"
+  }
+}

--- a/financely/tsconfig.base.json
+++ b/financely/tsconfig.base.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es2018",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}


### PR DESCRIPTION
## Summary
- bootstrap monorepo in `financely/` with yarn workspaces
- add React/Vite frontend with Tailwind, Storybook, hooks and tests
- scaffold Node GraphQL gateway and business service with typed resolvers
- add Go high-throughput deal matcher
- include Dockerfiles, Kubernetes manifests, GitHub Actions, and sample NATS events
- update README

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684a177bdb248328966843aaf0a7e9b9